### PR TITLE
Support subtype INTERNAL fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ the pattern.
 - You could alternatively clone Reviva and make changes there and push them, or if you're
   really lazy ask me to do it.
 
+If the part-to-internal relationship needs extra `INTERNAL` values such as an `offset`
+or `scale`, put those values in the selected B9 subtype's `ModuleIVASwitch` data. Reviva
+copies that nested node to the runtime `INTERNAL` config when the subtype is selected:
+
+```cfg
+MODULE
+{
+  IDENTIFIER
+  {
+    name = ModuleIVASwitch
+  }
+  DATA
+  {
+    internalName = ExampleInternal
+    INTERNAL
+    {
+      offset = 0, 0, 0
+    }
+  }
+}
+```
+
 Feel free to ask questions in the forum, I'm not super experienced with KSP modding, but I
 know game development well enough to be dangerous/helpful.
 

--- a/plugin/ModuleIVASwitch.cs
+++ b/plugin/ModuleIVASwitch.cs
@@ -25,7 +25,7 @@ namespace Reviva
 			// on initial loading, just change the config directly so that the correct IVA will be created through the normal pathways
 			if (vessel == null || !vessel.loaded)
 			{
-				UpdateInternalConfig(internalName);
+				UpdateInternalConfig(internalName, node);
 				return;
 			}
 
@@ -104,7 +104,7 @@ namespace Reviva
 			bool ivaWasActive = ivaWasSpawned && part.internalModel.gameObject.activeSelf;
 			this.part.DespawnIVA();
 
-			UpdateInternalConfig(newName);
+			UpdateInternalConfig(newName, updateConfig);
 
 			RebootRPMComputer();
 
@@ -183,10 +183,16 @@ namespace Reviva
 			return this.internalName ?? "";
 		}
 
-		private void UpdateInternalConfig(string newName)
+		private void UpdateInternalConfig(string newName, ConfigNode moduleConfig)
 		{
 			ConfigNode newInternalConfig = new ConfigNode("INTERNAL");
-			newInternalConfig.AddValue("name", newName);
+			ConfigNode configuredInternal = moduleConfig?.GetNode("INTERNAL");
+			if (configuredInternal != null)
+			{
+				configuredInternal.CopyTo(newInternalConfig);
+			}
+
+			newInternalConfig.SetValue("name", newName, true);
 			this.part.partInfo = new AvailablePart(this.part.partInfo); // clone the partinfo so we don't affect all instances of this part
 			this.part.partInfo.internalConfig = newInternalConfig;
 		}


### PR DESCRIPTION
## Summary
- let each selected B9 subtype provide its own nested `INTERNAL` values for Reviva's runtime part config
- keep the runtime `INTERNAL` name synchronized with the selected subtype
- document how subtype authors can provide fields such as `offset` for part/internal relationships that need them

Fixes #35.

## Validation
- `git diff --check`
- `dotnet build Reviva.sln -c Release --no-restore /p:KSPRoot="/home/sean/.local/share/Steam/steamapps/common/Kerbal Space Program"`: 0 warnings, 0 errors

## Caveat
I have not run an in-game shuttle runtime test, so this remains a draft for maintainer review.
